### PR TITLE
Added public property to see if the server is listening

### DIFF
--- a/Runtime/LLM.cs
+++ b/Runtime/LLM.cs
@@ -38,14 +38,8 @@ namespace LLMUnity
         [HideInInspector] public float modelCopyProgress = 1;
         private static float binariesDone = 0;
         private Process process;
-        private bool serverListening = false;
+        public bool serverListening { get; private set} = false;
         private ManualResetEvent serverBlock = new ManualResetEvent(false);
-
-        /// <summary>
-        /// Returns true if the server is listening.
-        /// </summary>
-        public bool ServerListening => serverListening;
-
         private static string GetAssetPath(string relPath = "")
         {
             // Path to store llm server binaries and models

--- a/Runtime/LLM.cs
+++ b/Runtime/LLM.cs
@@ -41,6 +41,11 @@ namespace LLMUnity
         private bool serverListening = false;
         private ManualResetEvent serverBlock = new ManualResetEvent(false);
 
+        /// <summary>
+        /// Returns true if the server is listening.
+        /// </summary>
+        public bool ServerListening => serverListening;
+
         private static string GetAssetPath(string relPath = "")
         {
             // Path to store llm server binaries and models


### PR DESCRIPTION
Had some trouble to know if the server was active from outside the LLM component. Because of this I added a property (`ServerListening`) to the `Llm.cs`. Had the idea it might be usefull.