### PR TITLE
Removed duplicate EditorGUI.EndChangeCheck()

### DIFF
--- a/Editor/LLMClientEditor.cs
+++ b/Editor/LLMClientEditor.cs
@@ -135,7 +135,7 @@ namespace LLMUnity
             AddServerSettings(llmScriptSO);
             AddModelLoadersSettings(llmScriptSO, llmScript);
             AddChatSettings(llmScriptSO);
-            EditorGUI.EndChangeCheck();
+            
             if (EditorGUI.EndChangeCheck())
                 Repaint();
 

--- a/Editor/LLMEditor.cs
+++ b/Editor/LLMEditor.cs
@@ -89,8 +89,7 @@ namespace LLMUnity
             AddModelLoadersSettings(llmScriptSO, llmScript);
             GUI.enabled = true;
             AddChatSettings(llmScriptSO);
-
-            EditorGUI.EndChangeCheck();
+            
             if (EditorGUI.EndChangeCheck())
                 Repaint();
 


### PR DESCRIPTION
From issues #100. I've removed the `EditorGUI.EndChangeCheck()` in both the `LLMEditor.cs` and `LLMClientEditor.cs` scripts.
Performance is back to as it should be and I haven't noticed any negative behaviour from this change.