### PR TITLE
Fallback to CPU for macOS with unsupported GPU

### DIFF
--- a/Runtime/LLM.cs
+++ b/Runtime/LLM.cs
@@ -316,7 +316,8 @@ namespace LLMUnity
             if (numThreads > 0) arguments += $" -t {numThreads}";
             if (loraPath != "") arguments += $" --lora {EscapeSpaces(loraPath)}";
 
-            string GPUArgument = numGPULayers <= 0 ? "" : $" -ngl {numGPULayers}";
+            string noGPUArgument = " -ngl 0 --gpu no";
+            string GPUArgument = numGPULayers <= 0 ? noGPUArgument : $" -ngl {numGPULayers}";
             LLMUnitySetup.makeExecutable(server);
 
             RunServerCommand(server, arguments + GPUArgument);
@@ -339,7 +340,7 @@ namespace LLMUnity
                 Debug.Log("GPU failed, fallback to CPU");
                 serverBlock.Reset();
 
-                RunServerCommand(server, arguments);
+                RunServerCommand(server, arguments + noGPUArgument);
                 if (asynchronousStartup) await WaitOneASync(serverBlock, TimeSpan.FromSeconds(60));
                 else serverBlock.WaitOne(60000);
             }

--- a/Runtime/LLM.cs
+++ b/Runtime/LLM.cs
@@ -254,15 +254,8 @@ namespace LLMUnity
         {
             string binary = exe;
             string arguments = args;
-
-            List<(string, string)> environment = null;
             if (Application.platform == RuntimePlatform.LinuxEditor || Application.platform == RuntimePlatform.LinuxPlayer)
             {
-                if (numGPULayers <= 0)
-                {
-                    // prevent nvcc building if not using GPU
-                    environment = new List<(string, string)> { ("PATH", ""), ("CUDA_PATH", "") };
-                }
                 // use APE binary directly if on Linux
                 arguments = $"{EscapeSpaces(binary)} {arguments}";
                 binary = SelectApeBinary();
@@ -274,7 +267,7 @@ namespace LLMUnity
                 binary = "sh";
             }
             Debug.Log($"Server command: {binary} {arguments}");
-            process = LLMUnitySetup.CreateProcess(binary, arguments, CheckIfListening, ProcessError, ProcessExited, environment);
+            process = LLMUnitySetup.CreateProcess(binary, arguments, CheckIfListening, ProcessError, ProcessExited);
         }
 
         private async Task StartLLMServer()


### PR DESCRIPTION
The metal GPU isn't supported on some mac (see https://github.com/ggerganov/llama.cpp/issues/4998).
This PR explicitly disables GPU when not needed or not supported to get around this issue.