### PR TITLE
Call DontDestroyOnLoad on root to remove warning

### DIFF
--- a/Runtime/LLM.cs
+++ b/Runtime/LLM.cs
@@ -214,7 +214,7 @@ namespace LLMUnity
             slotSaveDir = Application.persistentDataPath;
             if (asynchronousStartup) await Task.Run(() => StartLLMServer());
             else StartLLMServer();
-            if (dontDestroyOnLoad) DontDestroyOnLoad(gameObject);
+            if (dontDestroyOnLoad) DontDestroyOnLoad(transform.root.gameObject);
         }
 
         private void SetupLogging()


### PR DESCRIPTION
When calling DontDestroyOnLoad on a child object it won't work and logs a warning. Calling it on the transform.root.gameObject instead will always work.