### PR TITLE
Add contributing guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project team member. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md.meta
+++ b/CODE_OF_CONDUCT.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: df335783a8d8a4e53bbe626c147d010f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing to LLMUnity
+
+:+1: :tada: :heart: Thanks for your interest! :heart: :tada: :+1:
+
+The following is a set of guidelines for contributing to [LLMUnity](https://github.com/undreamai/LLMUnity). These are just guidelines, not rules. Use your best judgment, and
+feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Code of Conduct](#code-of-conduct)
+  * [Set up your dev environment](#set-up-your-dev-environment)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Good First Issue](#good-first-issue)
+  * [Issue and Pull Request Labels](#issue-and-pull-request-labels)
+
+
+## How Can I Contribute?
+
+### Code of Conduct
+
+This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code.
+
+### Set up your dev environment
+
+
+1. Fork the repo.
+2. Clone your forked repo into a Unity project's `Assets`.
+3. Create a symbolic link to `Samples~`, for example with:
+  ```bash
+  cd Assets && ln -s ./LLMUnity/Samples~ ./Samples 
+  ```
+4. Add the package to your projects libraries `Packages/manifest.json`:
+  ```json
+  "ai.undream.llm": "file:path/to/project/Assets/LLMUnity",
+  ```
+5. Create a topic branch from where you want to base your work.
+Name your branch prefixed with an appropriate [label](https://github.com/undreamai/LLMUnity/labels), following the naming convention `enhancement/*`, `bug/*`, `documentation/*`, etc. Make commits of logical units.
+6. Set up pre-commit hooks with `sh ./.github/setup.sh`
+
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for LLMUnity.
+Following these guidelines helps maintainers and the community understand your
+report :pencil:, reproduce the behavior :computer:, and find related
+reports :mag_right:.
+
+Before creating bug reports, please check [this section](#before-submitting-a-bug-report)
+as you might find out that you don't need to create one. When you are creating
+a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report) as it helps us resolve issues faster.
+
+#### Before Submitting A Bug Report
+
+**Perform a [cursory search](https://github.com/undreamai/LLMUnity/labels/bug)**
+to see if the problem has already been reported. If it does exist, add a
+[reaction](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/#reacting-to-ideas-in-issues-and-pull-requests)
+to the issue to indicate this is also an issue for you, and add a
+comment to the existing issue if there is extra information you can contribute.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
+
+Simply create an issue on the [LLMUnity issue tracker](https://github.com/undreamai/LLMUnity/issues), choose the appropriate provided issue template and fill it out.
+
+The information we are interested in includes:
+
+ - details about your environment - which build, which operating system
+ - details about reproducing the issue - what steps to take, what happens, how
+   often it happens
+ - other relevant information - log files, screenshots, etc.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for
+LLMUnity, including completely new features and minor improvements to
+existing functionality. Following these guidelines helps maintainers and the
+community understand your suggestion :pencil: and find related suggestions
+:mag_right:.
+
+Before creating enhancement suggestions, please check [this section](#before-submitting-an-enhancement-suggestion)
+as you might find out that you don't need to create one. When you are creating
+an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
+
+#### Before Submitting An Enhancement Suggestion
+
+**Perform a [cursory search](https://github.com/undreamai/LLMUnity/labels/enhancement)**
+to see if the enhancement has already been suggested. If it has, add a
+:thumbsup: to indicate your interest in it, or comment if there is additional
+information you would like to add.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).
+
+Simply create an issue on the [LLMUnity issue tracker](https://github.com/undreamai/LLMUnity/issues), choose the appropriate provided issue template and fill it out and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the
+  suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as
+  much detail as possible. This additional context helps the maintainers to
+  understand the enhancement from your perspective
+* **Explain why this enhancement would be useful** to LLMUnity users.
+* **Include screenshots and animated GIFs** if relevant to help you demonstrate
+  the steps or point out the part of LLMUnity which the suggestion is
+  related to. You can use [this tool](http://www.cockos.com/licecap/) to record
+  GIFs on macOS and Windows.
+* **List some other applications where this enhancement exists, if applicable.**
+
+### Good First Issue
+
+We'll identify enhancements or bugs that can be categorized as tasks that:
+
+ - have low impact, or have a known workaround
+ - should be fixed
+ - have a narrow scope and/or easy reproduction steps
+ - can be worked on independent of other tasks
+
+These issues will be labelled as [`good-first-issue`](https://github.com/undreamai/LLMUnity/labels/good%20first%20issue)
+in the repository. If you are interested in contributing to the project, please
+comment on the issue to let the maintainers (and community) know you are
+interested in picking this up.
+
+### Issue and Pull Request Labels
+
+See [this page](https://github.com/undreamai/LLMUnity/labels) for the list of the labels we use to help us track and manage issues and pull requests.
+
+
+
+

--- a/CONTRIBUTING.md.meta
+++ b/CONTRIBUTING.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0cf827c3ba62e4d598d999b5d39345b5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ LLM for Unity is built on top of the awesome [llama.cpp](https://github.com/gger
 ## How to help
 - [⭐ Star](https://github.com/undreamai/LLMUnity) the repo, leave us a [review](https://assetstore.unity.com/packages/slug/273604) and spread the word about the project!
 - Join us at [Discord](https://discord.gg/RwXKQb6zdv) and say hi!
-- Submit feature requests or bugs as issues or even submit a PR and become a collaborator
+- [Contribute](CONTRIBUTING.md) by submitting feature requests or bugs as issues or even submiting a PR and become a collaborator!
 
 ## Games using LLM for Unity
 - [Verbal Verdict](https://store.steampowered.com/app/2778780/Verbal_Verdict/)


### PR DESCRIPTION
# Context
From Issue #200: The package is missing contributing guidelines. 

# Additions

This PR aims to add:

- code of conduct
- dev environment set up
- workflow for bugs/enhancements/issues/PR


## Notes

Used these two repos for inspiration:
- [ExtendRealityLtd](https://github.com/ExtendRealityLtd/.github/blob/master/CONTRIBUTING.md)
- [github-for-unity](https://github.com/github-for-unity/Unity/blob/master/CONTRIBUTING.md). 

Also I am not really familiar with this project so please leave suggestions on what these guidelines should actually include!

## Questions

- Is there a general package-email people can reach out to?