### PR TITLE
Fixed build conflict, endless import of resources.

### DIFF
--- a/Editor/LLMBuildProcessor.cs
+++ b/Editor/LLMBuildProcessor.cs
@@ -51,8 +51,17 @@ namespace LLMUnity
 
         public void BuildCompleted()
         {
+#if UNITY_6000
+            // Delay the reset operation to ensure Unity is no longer in the build process
+            EditorApplication.delayCall += () =>
+            {
+                Application.logMessageReceived -= OnBuildError;
+                LLMBuilder.Reset();
+            };
+#else
             Application.logMessageReceived -= OnBuildError;
             LLMBuilder.Reset();
+#endif
         }
     }
 }

--- a/Editor/LLMBuildProcessor.cs
+++ b/Editor/LLMBuildProcessor.cs
@@ -51,17 +51,12 @@ namespace LLMUnity
 
         public void BuildCompleted()
         {
-#if UNITY_6000
             // Delay the reset operation to ensure Unity is no longer in the build process
             EditorApplication.delayCall += () =>
             {
                 Application.logMessageReceived -= OnBuildError;
                 LLMBuilder.Reset();
             };
-#else
-            Application.logMessageReceived -= OnBuildError;
-            LLMBuilder.Reset();
-#endif
         }
     }
 }


### PR DESCRIPTION
Fixed build conflict, endless import of resources. Delay the reset operation to ensure Unity is no longer in the build process. For Unity 6