### PR TITLE
ommit port from call if 0

### DIFF
--- a/Runtime/LLMCaller.cs
+++ b/Runtime/LLMCaller.cs
@@ -281,7 +281,7 @@ namespace LLMUnity
 
             while (tryNr != 0)
             {
-                using (request = UnityWebRequest.Put($"{host}:{port}/{endpoint}", jsonToSend))
+                using (request = UnityWebRequest.Put($"{host}{(port != 0 ? $":{port}" : "")}/{endpoint}", jsonToSend))
                 {
                     WIPRequests.Add(request);
 

--- a/Runtime/LLMCaller.cs
+++ b/Runtime/LLMCaller.cs
@@ -36,7 +36,7 @@ namespace LLMUnity
         [Tooltip("host of the remote LLM server")]
         [Remote] public string host = "localhost";
         /// <summary> port of the remote LLM server </summary>
-        [Tooltip("port of the remote LLM server")]
+        [Tooltip("port of the remote LLM server; use '0' to omit specifying a port (http/https)")]
         [Remote] public int port = 13333;
         /// <summary> number of retries to use for the remote LLM server requests (-1 = infinite) </summary>
         [Tooltip("number of retries to use for the remote LLM server requests (-1 = infinite)")]


### PR DESCRIPTION
If the url has no port this breaks the call, so if the value is 0 it makes it so it doesnt use the port at all in the call

Could also do this with a bool to use a port or not but figured this is simpler