### PR TITLE
Ensure macOS build includes the required runtime library

### DIFF
--- a/Editor/LLMBuildProcessor.cs
+++ b/Editor/LLMBuildProcessor.cs
@@ -44,8 +44,10 @@ namespace LLMUnity
 #else
             string projPath = Path.Combine(outputPath, Path.GetFileName(outputPath) + ".xcodeproj", "project.pbxproj");
             if (!File.Exists(projPath)) return;
-            libraryFileNames.Add("libllamalib_osx-universal_acc.dylib");
-            libraryFileNames.Add("libllamalib_osx-universal_no-acc.dylib");
+            libraryFileNames.Add("libllamalib_osx-x64_acc.dylib");
+            libraryFileNames.Add("libllamalib_osx-x64_no-acc.dylib");
+            libraryFileNames.Add("libllamalib_osx-arm64_acc.dylib");
+            libraryFileNames.Add("libllamalib_osx-arm64_no-acc.dylib");
 #endif
 
             PBXProject project = new PBXProject();

--- a/Runtime/LLMBuilder.cs
+++ b/Runtime/LLMBuilder.cs
@@ -208,7 +208,6 @@ namespace LLMUnity
                     checkCUBLAS = true;
                     break;
                 case BuildTarget.StandaloneOSX:
-                    platforms.Add("osx-universal");
                     platforms.Add("osx-x64");
                     platforms.Add("osx-arm64");
                     break;


### PR DESCRIPTION
Hello,

I always find LLMUnity extremely easy to use and really appreciate your work.

I created this PR because when I build for macOS and launch the app, it fails with an error and does not run.
I believe the cause is a mismatch between the libraries bundled at build time and the library selected at runtime.

Specifically, the following code specifies the runtime library to load:
https://github.com/undreamai/LLMUnity/blob/main/Runtime/LlamaLib/LlamaLib.cs#L684-L687
(it uses osx-arm64 for Apple Silicon and osx-x64 for Intel)

However, the build-time library selection below bundles osx-universal, which leads to the mismatch:
https://github.com/undreamai/LLMUnity/blob/main/Runtime/LLMBuilder.cs#L210-L212

To address this, I added osx-arm64 and osx-x64 to the list of libraries bundled during the build. Since this is an additive change, I believe the only side effect is an increase in the macOS build size.

I would be grateful if you could consider merging it.

Thank you and best regards.