### PR TITLE
Set maximum presence penalty to 2

### DIFF
--- a/Runtime/LLMClient.cs
+++ b/Runtime/LLMClient.cs
@@ -87,7 +87,7 @@ namespace LLMUnity
 
         /// <summary>Presence penalty: reduce likelihood of any repeated token (0.0 = disabled)</summary>
         [Tooltip("Presence penalty: reduce likelihood of any repeated token (0.0 = disabled)")]
-        [ModelAdvanced, Range(0f, 1f)] public float presencePenalty = 0f;
+        [ModelAdvanced, Range(0f, 2f)] public float presencePenalty = 0f;
 
         /// <summary>Frequency penalty: reduce likelihood based on token frequency (0.0 = disabled)</summary>
         [Tooltip("Frequency penalty: reduce likelihood based on token frequency (0.0 = disabled)")]


### PR DESCRIPTION
Some models have recommended presence penalty that is higher than 1, for example Qwen3.5 0.8B:

https://huggingface.co/Qwen/Qwen3.5-0.8B

<img width="623" height="627" alt="Screenshot 2026-03-28 at 10 25 53 AM" src="https://github.com/user-attachments/assets/41ebef93-2f31-4bfa-b2a5-195ce5bb2057" />



Currently the presence penalty setting in LLMClient (inherited by LLMAgent) has the upper limit of 1.
This PR increases it to 2.